### PR TITLE
feat: Add initial Docker setup and hyper-mcp opengrep plugin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Ignore git files
+.git
+.gitignore
+
+# Ignore docker files
+.dockerignore
+Dockerfile
+
+# Ignore local development artifacts
+/out
+/bin
+*.wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release OCI Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Go image to create a build artifact.
+# https://hub.docker.com/_/golang
+FROM golang:1.21-alpine AS builder
+
+# Set the necessary environment variables for CGO and WASI build
+ENV CGO_ENABLED=0 GOOS=wasip1 GOARCH=wasm
+WORKDIR /src
+
+# Copy go.mod and go.sum files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code
+COPY . .
+
+# Build the WASM plugin
+RUN go build -o /out/plugin.wasm .
+
+# Use a minimal image to package the plugin
+FROM scratch
+WORKDIR /
+COPY --from=builder /out/plugin.wasm /plugin.wasm
+ENTRYPOINT [ "/plugin.wasm" ]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module hyper-mcp-opengrep-plugin
+
+go 1.23.4
+
+require github.com/extism/go-pdk v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/extism/go-pdk v1.1.3 h1:hfViMPWrqjN6u67cIYRALZTZLk/enSPpNKa+rZ9X2SQ=
+github.com/extism/go-pdk v1.1.3/go.mod h1:Gz+LIU/YCKnKXhgge8yo5Yu1F/lbv7KtKFkiCSzW/P4=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	"github.com/extism/go-pdk"
+)
+
+type OpenGrepRequest struct {
+	Args []string `json:"args"`
+}
+
+//export opengrep
+func opengrep() int32 {
+	// Read input from the host
+	input := pdk.Input()
+
+	// Unmarshal the JSON input into our struct
+	var req OpenGrepRequest
+	if err := json.Unmarshal(input, &req); err != nil {
+		pdk.SetError(fmt.Errorf("Error unmarshaling JSON input: %v", err))
+		return 1
+	}
+
+	// Check if any arguments were provided
+	if len(req.Args) == 0 {
+		pdk.SetError(fmt.Errorf("No arguments provided for opengrep command"))
+		return 1
+	}
+
+	// Construct the opengrep command with user-provided arguments
+	cmd := exec.Command("opengrep", req.Args...)
+
+	// Execute the command and get the combined output (stdout and stderr)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// If the command fails, output the error to the host, including the command's output
+		pdk.SetError(fmt.Errorf("Error executing opengrep: %v\nOutput: %s", err, string(output)))
+		// Still return 0 to send the output back, the error is in the message.
+		// A non-zero exit code from opengrep is not a plugin failure.
+	}
+
+	// Return the command's output to the host
+	pdk.Output(output)
+
+	return 0
+}
+
+func main() {}


### PR DESCRIPTION
- Created .dockerignore to exclude unnecessary files from Docker context.
- Added Dockerfile for building a Go-based WebAssembly plugin.
- Introduced go.mod and go.sum for dependency management.
- Implemented main.go with the opengrep function to handle command execution.
- Set up GitHub Actions workflow for releasing OCI images on tag pushes.