### PR TITLE
feat: Add attestations permission and build provenance step to workflows

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -12,6 +12,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -47,6 +48,13 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: "ghcr.io/${{ github.repository }}"
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write # This is required for signing the image.
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -69,6 +70,13 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: "ghcr.io/${{ github.repository }}"
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0


### PR DESCRIPTION
- Updated dev-release.yml and release.yml to include 'attestations: write' permission for enhanced security.
- Added a step to attest build provenance using the actions/attest-build-provenance@v2 action, ensuring the integrity of the built images.