### PR TITLE
fix: Update release workflow to correctly determine new release status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
       issues: write # needed to create release
       pull-requests: write # needed to create release
     outputs:
-      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
-      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_published: ${{ steps.semantic.outputs.version != '' }}
+      new_release_version: ${{ steps.semantic.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- Modified the logic for `new_release_published` and `new_release_version` outputs to check for non-empty version strings, ensuring accurate release detection in the workflow.