### PR TITLE
feat: Add OpenGrep MCP Plugin metadata to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ RUN go build -o /out/plugin.wasm .
 
 # Use a minimal image to package the plugin
 FROM scratch
+
+LABEL org.opencontainers.image.description="OpenGrep MCP Plugin"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.authors="ducthinh993"
+LABEL org.opencontainers.image.vendor="ducthinh993"
+LABEL org.opencontainers.image.url="https://github.com/ducthinh993/hyper-mcp-opengrep-plugin"
+
 WORKDIR /
 COPY --from=builder /out/plugin.wasm /plugin.wasm
 ENTRYPOINT [ "/plugin.wasm" ]


### PR DESCRIPTION
- Included labels for description, licenses, authors, vendor, and URL in the Dockerfile to enhance image metadata and provide better context for the OpenGrep MCP Plugin.