### PR TITLE
chore: Disable build provenance step in workflows

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -48,13 +48,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
 
-      - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: "ghcr.io/${{ github.repository }}"
-          subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          push-to-registry: true
+      # - name: Attest Build Provenance
+      #   uses: actions/attest-build-provenance@v2
+      #   with:
+      #     subject-name: "ghcr.io/${{ github.repository }}"
+      #     subject-digest: ${{ steps.build-and-push.outputs.digest }}
+      #     push-to-registry: true
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
 
-      - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: "ghcr.io/${{ github.repository }}"
-          subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          push-to-registry: true
+      # - name: Attest Build Provenance
+      #   uses: actions/attest-build-provenance@v2
+      #   with:
+      #     subject-name: "ghcr.io/${{ github.repository }}"
+      #     subject-digest: ${{ steps.build-and-push.outputs.digest }}
+      #     push-to-registry: true
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0


### PR DESCRIPTION
- Removed the 'Attest Build Provenance' step from dev-release.yml and release.yml workflows to streamline the build process.
- Added 'provenance: false' to the image build configuration to indicate that build provenance is not being attested.