### PR TITLE
chore: Update Docker build workflows to use version 6 and enable provenance

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -41,14 +41,14 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
+          provenance: true
 
       # - name: Attest Build Provenance
       #   uses: actions/attest-build-provenance@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,14 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
+          provenance: true
 
       # - name: Attest Build Provenance
       #   uses: actions/attest-build-provenance@v2

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+//go:build extism || !extism
+
 package main
 
 import (


### PR DESCRIPTION
- Upgraded docker/build-push-action from v5 to v6 in both dev-release.yml and release.yml workflows.
- Enabled build provenance by setting 'provenance: true' in the image build configuration.
- Added a build constraint in main.go for better compatibility with the extism build tag.